### PR TITLE
Replace subnetwork name  with vpc (#971)

### DIFF
--- a/applications/hcc/main.tf
+++ b/applications/hcc/main.tf
@@ -18,7 +18,7 @@ data "google_client_config" "default" {}
 
 locals {
   subnetwork_name = "${var.goog_cm_deployment_name}-gke-net"
-  result_bucket_name = "${var.goog_cm_deployment_name}-result"
+  result_bucket_name = "${var.project_id}-${var.goog_cm_deployment_name}-result"
   gke_cluster_id = var.gpu_type == "A3 Mega"? "${module.a3-megagpu-cluster[0].cluster_id}" : var.gpu_type == "A3 Ultra"? "${module.a3-ultragpu-cluster[0].cluster_id}" : error("Only A3 Mega and A3 Ultra are supported")
   gke_cluster_version = var.gpu_type == "A3 Mega"? "${module.a3-megagpu-cluster[0].gke_version}" : var.gpu_type == "A3 Ultra"? "${module.a3-ultragpu-cluster[0].gke_version}" : error("Only A3 Mega and A3 Ultra are supported")
 

--- a/applications/hcc/modules/embedded/modules/scheduler/gke-cluster/main.tf
+++ b/applications/hcc/modules/embedded/modules/scheduler/gke-cluster/main.tf
@@ -382,7 +382,7 @@ module "kubectl_apply" {
       {
         source = "${path.module}/templates/gke-network-paramset.yaml.tftpl",
         template_vars = {
-          name            = network_info.subnetwork,
+          name            = "vpc${idx + 1}",
           network_name    = network_info.network
           subnetwork_name = network_info.subnetwork,
           device_mode     = strcontains(upper(network_info.nic_type), "RDMA") ? "RDMA" : "NetDevice"
@@ -390,7 +390,7 @@ module "kubectl_apply" {
       },
       {
         source        = "${path.module}/templates/network-object.yaml.tftpl",
-        template_vars = { name = network_info.subnetwork }
+        template_vars = { name = "vpc${idx + 1}" }
       }
     ]
   ])

--- a/applications/hcc/modules/embedded/modules/scheduler/pre-existing-gke-cluster/main.tf
+++ b/applications/hcc/modules/embedded/modules/scheduler/pre-existing-gke-cluster/main.tf
@@ -46,7 +46,7 @@ locals {
       {
         source = "${path.module}/templates/gke-network-paramset.yaml.tftpl",
         template_vars = {
-          name            = network_info.subnetwork
+          name            = "vpc${idx + 1}" 
           network_name    = network_info.network
           subnetwork_name = network_info.subnetwork
           device_mode     = "NetDevice"
@@ -54,7 +54,7 @@ locals {
       },
       {
         source        = "${path.module}/templates/network-object.yaml.tftpl",
-        template_vars = { name = network_info.subnetwork }
+        template_vars = { name = "vpc${idx + 1}" }
       }
     ]
   ])


### PR DESCRIPTION
* Add A3 Ultra Cluster

* fix legacy module warning

* Add infra switch logic using Meta argument Count

* fix error

* Cleanup

* Add back default value

* Fix pip3 not found issue: the infra Manager image does not have python installed. k8s jobs in lanuchpad recipes already have the necessary tcpx/tcpxo config.

* Use vpc instead of subnetwork name